### PR TITLE
Add libicu66 dependency for Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y libicu-dev libidn11-dev
+            wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2_amd64.deb
+            sudo dpkg -i libicu66_66.1-2ubuntu2_amd64.deb
   prepare-yarn:
     steps:
       - run:


### PR DESCRIPTION
Circle CIでRuby 3.0が落ちているようだったので修正しています。
どうもRuby 3.0では `libicu66` がないようで、その影響で `charlock_holmes` がエラーを返すようです。

そのため `libicu66` を手動でインストールするようにCIを修正しています。
CircleCIでの実行結果などは[こちら](https://github.com/S-H-GAMELINKS/mastodon/pull/1430)から確認できるかと思います。

Ruby 3.0をCIから外すという選択肢もあるかと思いますので、マージするかどうかはお任せします。